### PR TITLE
Update memory getters in timers to use new HAL api

### DIFF
--- a/cpp_template.mustache
+++ b/cpp_template.mustache
@@ -116,13 +116,15 @@ void print_timers_data() {
 
 static void print_mem_usage() {
 	using namespace util;
-	auto mem_max = OS::memory_end();
-	auto total_memuse = OS::total_memuse();
-	auto heap_alloc = OS::heap_usage();
+	static auto mem_max = os::total_memuse();
+	auto total_memuse = os::total_memuse();
 
-	INFO("NaCl Timer Memory", "Total memory: %s, in use %0.1f%% (%s heap allocated)",
+	INFO("NaCl Timer Memory", "Total memory: %s, in use %0.1f%%",
 		Byte_r(mem_max).to_string().c_str(),
-		(double(total_memuse) / mem_max) * 100, Byte_r(heap_alloc).to_string().c_str());
+		(double(total_memuse) / mem_max) * 100);
+
+	if(total_memuse < mem_max)
+		mem_max = total_memuse;
 }
 
 //< Timer Memory

--- a/goldenfiles/timers.cpp
+++ b/goldenfiles/timers.cpp
@@ -98,13 +98,15 @@ void print_timers_data() {
 
 static void print_mem_usage() {
 	using namespace util;
-	auto mem_max = OS::memory_end();
-	auto total_memuse = OS::total_memuse();
-	auto heap_alloc = OS::heap_usage();
+	static auto mem_max = os::total_memuse();
+	auto total_memuse = os::total_memuse();
 
-	INFO("NaCl Timer Memory", "Total memory: %s, in use %0.1f%% (%s heap allocated)",
+	INFO("NaCl Timer Memory", "Total memory: %s, in use %0.1f%%",
 		Byte_r(mem_max).to_string().c_str(),
-		(double(total_memuse) / mem_max) * 100, Byte_r(heap_alloc).to_string().c_str());
+		(double(total_memuse) / mem_max) * 100);
+
+	if(total_memuse < mem_max)
+		mem_max = total_memuse;
 }
 
 //< Timer Memory


### PR DESCRIPTION
Haven't been able to actually run the timer due to uplink dependency, but it compiles.