### PR TITLE
adding conan recipe and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,72 @@
+pipeline {
+  agent { label 'ubuntu-18.04' }
+
+  environment {
+    CONAN_USER_HOME = "${env.WORKSPACE}"
+    PROFILE_x86_64 = 'clang-6.0-linux-x86_64'
+    PROFILE_x86 = 'clang-6.0-linux-x86'
+    CPUS = """${sh(returnStdout: true, script: 'nproc')}"""
+    CC = 'clang-6.0'
+    CXX = 'clang++-6.0'
+    PACKAGE = 'NaCl'
+    USER = 'includeos'
+    CHAN = 'test'
+    REMOTE = "${env.CONAN_REMOTE}"
+    BINTRAY_CREDS = credentials('devops-includeos-user-pass-bintray')
+  }
+
+  stages {
+    stage('Setup') {
+      steps {
+        sh script: "conan config install https://github.com/includeos/conan_config.git", label: "conan config install"
+      }
+    }
+    stage('Pull Request pipeline') {
+      when { changeRequest() }
+      stages {
+        stage('Build package') {
+          steps {
+            build_conan_package("$PROFILE_x86_64")
+          }
+        }
+      }
+    }
+    stage('Deploy package pipeline') {
+      when {
+        anyOf {
+          branch 'master'
+        }
+      }
+      stages {
+        stage('Build Conan package') {
+          steps {
+            //TODO foreach profile ?
+            build_conan_package("$PROFILE_x86_64")
+          }
+        }
+        stage('Upload to bintray') {
+          steps {
+            sh script: """
+              conan user -p $BINTRAY_CREDS_PSW -r $REMOTE $BINTRAY_CREDS_USR
+              VERSION=\$(conan inspect -a version . | cut -d " " -f 2)
+              conan upload --all -r $REMOTE $PACKAGE/\$VERSION@$USER/$CHAN
+            """, label: "Upload to bintray"
+          }
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      sh script: """
+        VERSION=\$(conan inspect -a version . | cut -d " " -f 2)
+        conan remove $PACKAGE/\$VERSION@$USER/$CHAN -f || echo 'Could not remove. This does not fail the pipeline'
+      """, label: "Cleaning up and removing conan package"
+    }
+  }
+}
+
+
+def build_conan_package(String profile) {
+  sh script: "conan create . $USER/$CHAN -pr ${profile}", label: "Build with profile: $profile"
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,58 @@
+
+from conans import ConanFile,tools
+import shutil
+
+def get_version():
+    git = tools.Git()
+    try:
+        prev_tag = git.run("describe --tags --abbrev=0")
+        commits_behind = int(git.run("rev-list --count %s..HEAD" % (prev_tag)))
+        # Commented out checksum due to a potential bug when downloading from bintray
+        #checksum = git.run("rev-parse --short HEAD")
+        if prev_tag.startswith("v"):
+            prev_tag = prev_tag[1:]
+        if commits_behind > 0:
+            prev_tag_split = prev_tag.split(".")
+            prev_tag_split[-1] = str(int(prev_tag_split[-1]) + 1)
+            output = "%s-%d" % (".".join(prev_tag_split), commits_behind)
+        else:
+            output = "%s" % (prev_tag)
+        return output
+    except:
+        return '0.0.0'
+
+class NaClConan(ConanFile):
+    name = 'nacl'
+    version = get_version()
+    license = 'Apache-2.0'
+    description='NaCl is a configuration language for IncludeOS that you can use to add for example interfaces and firewall rules to your service.'
+    url='https://github.com/includeos/NaCl'
+
+    scm = {
+        "type" : "git",
+        "url" : "auto",
+        "subfolder": ".",
+        "revision" : "auto"
+    }
+
+    default_user="includeos"
+    default_channel="test"
+
+    def build(self):
+        #you need antlr4 installed to do this
+        self.run("antlr4 -Dlanguage=Python2 NaCl.g4 -visitor")
+
+    def package(self):
+        name='NaCl'
+        self.copy('*',dst=name+"/subtranspilers",src="subtranspilers")
+        self.copy('*',dst=name+"/type_processors",src="type_processors")
+        self.copy('*.py',dst=name,src=".")
+        self.copy('cpp_template.mustache',dst=name,src='.')
+        self.copy('NaCl.tokens',dst=name,src=".")
+        self.copy('NaClLexer.tokens',dst=name,src=".")
+
+    def package_id(self):
+        self.info.header_only()
+
+    def deploy(self):
+        self.copy("*",dst="NaCl",src="NaCl")


### PR DESCRIPTION
Moved and updated conan recipe from [includeos/conan](https://github.com/includeos/conan)

To create a conan package for NaCl now:
`conan create <path-to-conanfile> -pr <profile-name> <user/channel>`
- user: `includeos`
- channel: `test`
The `Jenkinsfile` will now be picked up by IncludeOS Organization and executed on public Jenkins. 
This should build the package with the correct version based on the git tags.